### PR TITLE
Add autopoint.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install --yes --no-install-recommends \
     automake \
+    autopoint \
     bc \
     bison \
     ca-certificates \


### PR DESCRIPTION
This is required by some things which use autotools. The current
application is linux-pam 1.3.0, which fails to execute autogen.sh
without this dependency.