### PR TITLE
Use latest version of toolchain-native; Fixes conan issues too

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@
 #     ```
 #
 
-FROM wsbu/toolchain-native:v0.1.4
+FROM wsbu/toolchain-native:v0.2.2
 
 ENV WSBU_C_COMPILER=/opt/linaro/bin/arm-linux-gnueabihf-gcc \
   WSBU_CXX_COMPILER=/opt/linaro/bin/arm-linux-gnueabihf-g++ \

--- a/docker-linaro
+++ b/docker-linaro
@@ -8,6 +8,7 @@ set -e
 
 mkdir --parents ~/.conan/data
 touch ~/.conan/.conan.db
+touch ~/.conan/registry.txt
 
 set -x
 docker run -it --rm \
@@ -19,6 +20,7 @@ docker run -it --rm \
     -v "$HOME/.ssh/known_hosts:/home/captain/.ssh/known_hosts" \
     -v "${dir}:${dir}" \
     -v "$HOME/.conan/data:/home/captain/.conan/data" \
+    -v "$HOME/.conan/registry.txt:/home/captain/.conan/registry.txt" \
     -v "$HOME/.conan/.conan.db:/home/captain/.conan/.conan.db" \
     wsbu/toolchain-linaro "$@"
 


### PR DESCRIPTION
Testing in base has NOT BEEN CONDUCTED yet, so base should not be updated to use this new image yet. But, the latest version of toolchain native fixes a conan issue and it'd be great to get that fix applied to the linaro toolchain as well. Also.. Ubuntu 18.04.