### PR TITLE
[MAN-1574] Update upstream Docker image to use new Conan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wsbu/toolchain-native:v0.3.4
+FROM wsbu/toolchain-native:v0.3.5
 
 ENV WSBU_C_COMPILER=arm-linux-gnueabihf-gcc \
   WSBU_CXX_COMPILER=arm-linux-gnueabihf-g++ \

--- a/docker-linaro
+++ b/docker-linaro
@@ -33,4 +33,4 @@ docker run -it --rm \
     -v "$HOME/.conan/data:/home/captain/.conan/data" \
     -v "$HOME/.conan/remotes.json:/home/captain/.conan/remotes.json" \
     -v "$HOME/.conan/.conan.db:/home/captain/.conan/.conan.db" \
-    wsbu/toolchain-linaro:3.0.1 "$@"
+    wsbu/toolchain-linaro:3.0.2 "$@"


### PR DESCRIPTION
This realizes the change made to the upstream Docker image and allows us to build the (latest WSBU) Linux kernel as a Conan artifact.