### PR TITLE
[MAN-1679] Update to base image (conan, gperf); use proper linux Conan dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wsbu/toolchain-native:v0.3.5
+FROM wsbu/toolchain-native:v0.3.6
 
 ENV WSBU_C_COMPILER=arm-linux-gnueabihf-gcc \
   WSBU_CXX_COMPILER=arm-linux-gnueabihf-g++ \

--- a/conan/sitara_profile
+++ b/conan/sitara_profile
@@ -1,5 +1,5 @@
 [build_requires]
-linux/4.9.59@wsbu/stable
+linux/4.9.119@wsbu/stable
 [settings]
 os=Linux
 os_build=Linux

--- a/docker-linaro
+++ b/docker-linaro
@@ -33,4 +33,4 @@ docker run -it --rm \
     -v "$HOME/.conan/data:/home/captain/.conan/data" \
     -v "$HOME/.conan/remotes.json:/home/captain/.conan/remotes.json" \
     -v "$HOME/.conan/.conan.db:/home/captain/.conan/.conan.db" \
-    wsbu/toolchain-linaro:3.0.2 "$@"
+    wsbu/toolchain-linaro:3.0.3 "$@"


### PR DESCRIPTION
Updating the base image to get new gperf and new conan. Also fixed Conan's dependency on Linux to use the more recent Linux kernel.