### PR TITLE
[MAN-1750] Upgrade conan to support lockfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wsbu/toolchain-native:v0.3.7
+FROM wsbu/toolchain-native:v0.3.8
 
 ENV WSBU_C_COMPILER=arm-linux-gnueabihf-gcc \
   WSBU_CXX_COMPILER=arm-linux-gnueabihf-g++ \

--- a/docker-linaro
+++ b/docker-linaro
@@ -33,4 +33,4 @@ docker run -it --rm \
     -v "$HOME/.conan/data:/home/captain/.conan/data" \
     -v "$HOME/.conan/remotes.json:/home/captain/.conan/remotes.json" \
     -v "$HOME/.conan/.conan.db:/home/captain/.conan/.conan.db" \
-    wsbu/toolchain-linaro:3.0.4 "$@"
+    wsbu/toolchain-linaro:3.0.5 "$@"


### PR DESCRIPTION
This pulls in the fix from conan-io/conan#5499, allowing us to use lockfiles in base.