### PR TITLE
toolchain-linaro: Add libncurses5-dev to this docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
       gcc-arm-linux-gnueabihf \
       g++-arm-linux-gnueabihf \
       gccgo-arm-linux-gnueabihf \
-    && rm --recursive --force /var/lib/apt/lists/* \
+      libncurses5-dev \
+      && rm --recursive --force /var/lib/apt/lists/* \
   && pip3 --no-cache-dir install python-magic \
   && mkdir --parents $HOME/.ssh \
   && ln -sf "${HOME}/.conan/profiles/sitara" "${HOME}/.conan/profiles/default" \

--- a/docker-linaro
+++ b/docker-linaro
@@ -33,4 +33,5 @@ docker run -it --rm \
     -v "$HOME/.conan/data:/home/captain/.conan/data" \
     -v "$HOME/.conan/remotes.json:/home/captain/.conan/remotes.json" \
     -v "$HOME/.conan/.conan.db:/home/captain/.conan/.conan.db" \
-    wsbu/toolchain-linaro:3.0.6 "$@"
+    wsbu/toolchain-linaro:3.0.7 "$@"
+


### PR DESCRIPTION
This package in required in order to run "make menuconfig" to configure the
building of the linux kernel and kernel modules.